### PR TITLE
fix: fallback recipient name should not be truncated <=38 chars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>fr.insee.pearljam</groupId>
 	<artifactId>pearljam-batch</artifactId>
-	<version>3.4.4</version>
+	<version>3.4.5</version>
 	<packaging>jar</packaging>
 	<name>pearljam-batch</name>
 	<description>PearlJam Batch</description>

--- a/src/main/java/fr/insee/pearljam/batch/service/impl/CommunicationServiceImpl.java
+++ b/src/main/java/fr/insee/pearljam/batch/service/impl/CommunicationServiceImpl.java
@@ -81,6 +81,9 @@ public class CommunicationServiceImpl implements CommunicationService {
 			} catch (MissingAddressException | NullPointerException e) {
 				LOGGER.warn("Skipping survey unit {} due to address or interviewer error: {}", su.getId(), e.getMessage());
 				failedSurveyUnits.add(su.getId());
+			} catch(Exception e){
+				LOGGER.warn("Skipping survey unit {} due unexpected error: {}", su.getId(), e.getMessage(), e);
+				failedSurveyUnits.add(su.getId());
 			}
 		}
 
@@ -107,7 +110,7 @@ public class CommunicationServiceImpl implements CommunicationService {
 			}
 
 			updateStatus(communicationDataList, templateId, published);
-			LOGGER.info("Communication {} => {}", courriers.getEditionId(), published ? "OK" : "KO");
+			LOGGER.info("Communication {} => {}, {} communication(s) send", courriers.getEditionId(), published ? "OK" : "KO",courriers.getCourriers().size());
 		}
 
 		if (!failedSurveyUnits.isEmpty()) {
@@ -260,11 +263,11 @@ public class CommunicationServiceImpl implements CommunicationService {
 		data.setInterviewerTel(interviewer.getPhoneNumber());
 	}
 
-	private String generateRecipientName(PersonType person) {
+	String generateRecipientName(PersonType person) {
 		String title = person.getTitle().equals("MISS") ? "MME" : "M";
 
 		String firstName = person.getFirstName();
-		List<String> composedFirstName = Arrays.stream(firstName.split(" ")).toList();
+		List<String> composedFirstName = Arrays.stream(firstName.split("[ -]")).toList();
 		String lastName = person.getLastName();
 
 		String recipientCompleteName = String.join(" ", title, firstName, lastName);
@@ -274,11 +277,12 @@ public class CommunicationServiceImpl implements CommunicationService {
 		if (recipientShortName.length() <= 38) return recipientShortName;
 
 		String firstNameAcronym =
-				composedFirstName.stream().map(str -> str.substring(0, 1)).collect(Collectors.joining(" ")).toUpperCase();
+				composedFirstName.stream().map(str -> str.substring(0, 1)).collect(Collectors.joining(".")).toUpperCase();
 		String recipientShorterName = String.join(" ", title, firstNameAcronym, lastName);
 		if (recipientShorterName.length() <= 38) return recipientShorterName;
 
-		return String.join(" ", title, lastName).substring(0, 38);
+		String recipientShortestName = String.join(" ", title, lastName);
+		return recipientShortestName.length() <= 38 ? recipientShortestName : recipientShortestName.substring(0, 38);
 	}
 
 	public void moveFileAfterPublish(boolean publishResult, File fileToPublish, String communicationModele) throws PublicationException {

--- a/src/test/java/fr/insee/pearljam/batch/service/impl/CommunicationServiceImplTest.java
+++ b/src/test/java/fr/insee/pearljam/batch/service/impl/CommunicationServiceImplTest.java
@@ -1,0 +1,94 @@
+package fr.insee.pearljam.batch.service.impl;
+import fr.insee.pearljam.batch.campaign.PersonType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommunicationServiceImplTest {
+
+    private CommunicationServiceImpl communicationService;
+
+    @BeforeEach
+    void setUp() {
+        communicationService = new CommunicationServiceImpl(   null, null, null, null, null,
+                null, null, null, null);
+    }
+
+    @Test
+    void testSimpleFemaleName()  {
+        PersonType person = new MockPerson("MISS", "Alice", "Durand");
+        String result = communicationService.generateRecipientName(person);
+        assertEquals("MME Alice Durand", result);
+    }
+
+    @Test
+    void testSimpleMaleName()  {
+        PersonType person = new MockPerson("MR", "Pierre", "Martin");
+        String result = communicationService.generateRecipientName(person);
+        assertEquals("M Pierre Martin", result);
+    }
+
+    @Test
+    void testHyphenatedFemaleName()  {
+        PersonType person = new MockPerson("MISS", "Marie-Claire", "Moreau");
+        String result = communicationService.generateRecipientName(person);
+        assertEquals("MME Marie-Claire Moreau", result);
+    }
+
+    @Test
+    void testMaleComposedNameKeepFirst()  {
+        PersonType person = new MockPerson("MR", "Jean Michel Louis", "DupontelEstVraimentLong");
+        String result = communicationService.generateRecipientName(person);
+        assertEquals("M Jean DupontelEstVraimentLong", result);
+    }
+
+    @Test
+    void testMaleComposedFirstNameFallbackToAcronym()  {
+        PersonType person = new MockPerson("MR", "Maxence Michel-Arnaud", "DupontelleEstVraimentTrèsLong");
+        String result = communicationService.generateRecipientName(person);
+        assertEquals("M M.M.A DupontelleEstVraimentTrèsLong", result);
+    }
+
+    @Test
+    void testFemaleKeepOnlyName()  {
+        PersonType person = new MockPerson("MISS", "Catherine", "DucheminVraimentTrèsLongNomComposé");
+        String result = communicationService.generateRecipientName(person);
+        assertEquals("MME DucheminVraimentTrèsLongNomComposé", result);
+    }
+
+    @Test
+    void testFemaleNameFallbackToTruncation()  {
+        PersonType person = new MockPerson("MISS", "Catherine", "DeLaVallièreVraimentTrèsLongNomComposé");
+        String result = communicationService.generateRecipientName(person);
+        assertEquals("MME DeLaVallièreVraimentTrèsLongNomCom", result);
+        assertEquals(38, result.length());
+    }
+
+    // Helper mock implementation of PersonType
+    static class MockPerson extends PersonType {
+        private final String title;
+        private final String firstName;
+        private final String lastName;
+
+        public MockPerson(String title, String firstName, String lastName) {
+            this.title = title;
+            this.firstName = firstName;
+            this.lastName = lastName;
+        }
+
+        @Override
+        public String getTitle() {
+            return title;
+        }
+
+        @Override
+        public String getFirstName() {
+            return firstName;
+        }
+
+        @Override
+        public String getLastName() {
+            return lastName;
+        }
+    }
+}


### PR DESCRIPTION
* fix: fallback recipient name should not be truncated if length is <=38 cars

* feat: composed firstName mixed separators

* fix: log full stacktrace on unexpected exceptions